### PR TITLE
update Julia version for dependent images

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ The default user in the image is `root` with home directory `/root`. The default
 
 Description                     | Image & Latest Version (julialang/...)
 --------------------------------|-----------------------------------------------------------------------------
-Base Julia                      | [julia:v0.3.8](https://registry.hub.docker.com/u/julialang/julia/)
-JuliaBox minimal package bundle | [juliaboxminpkgdist:v0.3.8](https://registry.hub.docker.com/u/julialang/juliaboxminpkgdist/)
-JuliaBox package bundle         | [juliaboxpkgdist:v0.3.8](https://registry.hub.docker.com/u/julialang/juliaboxpkgdist/)
-Julia Hadoop                    | [hadoop:v0.4.0_build3](https://registry.hub.docker.com/u/julialang/hadoop/)
+Base Julia                      | [julia:v0.3.9](https://registry.hub.docker.com/u/julialang/julia/)
+Base Julia                      | [julia:v0.4.0](https://registry.hub.docker.com/u/julialang/julia/)
+JuliaBox minimal package bundle | [juliaboxminpkgdist:v0.3.9](https://registry.hub.docker.com/u/julialang/juliaboxminpkgdist/)
+JuliaBox package bundle         | [juliaboxpkgdist:v0.3.9](https://registry.hub.docker.com/u/julialang/juliaboxpkgdist/)
+Julia Hadoop                    | [hadoop:v0.4.0_build4](https://registry.hub.docker.com/u/julialang/hadoop/)
 
 ## Contributing
 Please submit pull requests to update/add packages. As far as possible, please extend from an existing image specification to avoid duplication.

--- a/pkgdists/hadoop/Dockerfile
+++ b/pkgdists/hadoop/Dockerfile
@@ -1,5 +1,5 @@
 # Ubuntu Docker file for Julia with Hadoop
-# Version:v0.4.0_build3
+# Version:v0.4.0_build4
 
 FROM julialang/julia:v0.4.0
 

--- a/pkgdists/hadoop/README.md
+++ b/pkgdists/hadoop/README.md
@@ -16,16 +16,16 @@ Dockerfile points to the correct Julia nightly build.
 
 To pull a pre-built image from dockerhub, run:
 ````
-docker pull julialang/hadoop:v0.4.0_build3
-docker tag julialang/hadoop:v0.4.0_build3 julialang/hadoop:latest
+docker pull julialang/hadoop:v0.4.0_build4
+docker tag julialang/hadoop:v0.4.0_build4 julialang/hadoop:latest
 ````
 
 Alternatively, to build locally, run:
 ````
 git clone https://github.com/tanmaykm/JuliaDockerImages.git
 docker build -t julialang/julia:v0.4.0 JuliaDockerImages/base/v0.4
-docker build -t julialang/hadoop:v0.4.0_build3 JuliaDockerImages/pkgdists/hadoop
-docker tag julialang/hadoop:v0.4.0_build3 julialang/hadoop:latest
+docker build -t julialang/hadoop:v0.4.0_build4 JuliaDockerImages/pkgdists/hadoop
+docker tag julialang/hadoop:v0.4.0_build4 julialang/hadoop:latest
 ````
 
 ## Start standalone:

--- a/pkgdists/juliabox/Dockerfile
+++ b/pkgdists/juliabox/Dockerfile
@@ -1,8 +1,8 @@
 # Docker file for JuliaBox
 # Tag: julialang/juliaboxpkgdist
-# Version:v0.3.8
+# Version:v0.3.9
 
-FROM julialang/juliaboxminpkgdist:v0.3.8
+FROM julialang/juliaboxminpkgdist:v0.3.9
 
 MAINTAINER Tanmay Mohapatra
 

--- a/pkgdists/juliaboxminimal/Dockerfile
+++ b/pkgdists/juliaboxminimal/Dockerfile
@@ -1,8 +1,8 @@
 # Docker file for JuliaBox Minimal
 # Tag: julialang/juliaboxminpkgdist
-# Version:v0.3.8
+# Version:v0.3.9
 
-FROM julialang/julia:v0.3.8
+FROM julialang/julia:v0.3.9
 
 MAINTAINER Tanmay Mohapatra
 


### PR DESCRIPTION
Bumped base Julia image from 0.3.8 to 0.3.9 and also 0.4.0 to the latest nightly.

This updates the dependent Dockerfiles to the latest base version. Dockerhub build will be triggered subsequently
